### PR TITLE
Fix null object error on PoolMatchesTransformer.php

### DIFF
--- a/app/Http/Response/Transformers/PoolMatchesTransformer.php
+++ b/app/Http/Response/Transformers/PoolMatchesTransformer.php
@@ -11,8 +11,8 @@ class PoolMatchesTransformer extends TransformerAbstract
             'id'                => (int) $game->id,
             'scoreContender1'   => (int) $game->score_contender1,
             'scoreContender2'   => (int) $game->score_contender2,
-            'contender1Name'    => (string) $game->contender1->team->name,
-            'contender2Name'    => (string) $game->contender2->team->name,
+            'contender1Name'    => (string) (empty($game->contender1->team) ? 'no team': $game->contender1->team->name),
+            'contender2Name'    => (string) (empty($game->contender2->team) ? 'no team': $game->contender2->team->name),
             'startTime'         => $game->start_time,
             'isFinished'        => (bool) ($game->score_contender1 != 0 && $game->score_contender2 != 0)
         ];


### PR DESCRIPTION
When transforming data through API, no team object were given. Now it will check if it's empty before adding the name to the return. If it's true, it will put "no team" as team name.